### PR TITLE
feat(pros_car_py): 允許透過 ROS 參數控制 PyBullet GUI 

### DIFF
--- a/src/pros_car_py/pros_car_py/arm_controller.py
+++ b/src/pros_car_py/pros_car_py/arm_controller.py
@@ -12,10 +12,10 @@ import threading
 
 
 class ArmController:
-    def __init__(self, ros_communicator, data_processor, ik_solver, num_joints=4):
+    def __init__(self, ros_communicator, data_processor, ik_solver, num_joints=4, use_gui=True):
         # initail pybullet
         self.ik_solver = ik_solver
-        self.ik_solver.createWorld(GUI=True)
+        self.ik_solver.createWorld(GUI=use_gui)
 
         self.ros_communicator = ros_communicator
         self.data_processor = data_processor
@@ -91,8 +91,6 @@ class ArmController:
     # except:
     #     pass
     #     # self.ik_solver.setJointPosition(joint_angles)
-
-    #     self.update_action(self.joint_pos)
 
     # auto control--------------------------------------------------
     def auto_control(self, key=None, mode="auto_arm_control"):

--- a/src/pros_car_py/pros_car_py/ik_solver.py
+++ b/src/pros_car_py/pros_car_py/ik_solver.py
@@ -52,7 +52,9 @@ class PybulletRobotController:
     def createWorld(self, GUI=True, view_world=False):
         # load pybullet physics engine
         if GUI:
-            physicsClient = p.connect(p.GUI)
+            #FIX: MacOS叫GUI需要使用到X11/GLX，無法worl，先改成使用Direct
+            # physicsClient = p.connect(p.GUI)
+            physicsClient = p.connect(p.DIRECT)
         else:
             physicsClient = p.connect(p.DIRECT)
         p.setAdditionalSearchPath(pybullet_data.getDataPath())

--- a/src/pros_car_py/pros_car_py/ik_solver.py
+++ b/src/pros_car_py/pros_car_py/ik_solver.py
@@ -52,9 +52,7 @@ class PybulletRobotController:
     def createWorld(self, GUI=True, view_world=False):
         # load pybullet physics engine
         if GUI:
-            #FIX: MacOS叫GUI需要使用到X11/GLX，無法worl，先改成使用Direct
-            # physicsClient = p.connect(p.GUI)
-            physicsClient = p.connect(p.DIRECT)
+            hysicsClient = p.connect(p.GUI)
         else:
             physicsClient = p.connect(p.DIRECT)
         p.setAdditionalSearchPath(pybullet_data.getDataPath())

--- a/src/pros_car_py/pros_car_py/main2.py
+++ b/src/pros_car_py/pros_car_py/main2.py
@@ -5,6 +5,7 @@ import rclpy
 import time
 import io
 import sys
+from rclpy.node import Node # 確保已匯入 Node
 from pros_car_py.joint_config import JOINT_UPDATES_POSITIVE, JOINT_UPDATES_NEGATIVE
 from pros_car_py.car_controller import CarController
 from pros_car_py.arm_controller import ArmController
@@ -32,12 +33,21 @@ def init_ros_node():
 """
 def main():
     ros_communicator, ros_thread = init_ros_node()#這行程式碼的作用是呼叫 init_ros_node() 函式，並將它回傳的兩個值分別指定給變數 ros_communicator 和 ros_thread
+
+    # --- 開始修改: ROS 參數處理 ---
+    # 宣告 'gui' 參數，預設值為 True
+    ros_communicator.declare_parameter('gui', True)
+    # 讀取 'gui' 參數的值
+    use_gui = ros_communicator.get_parameter('gui').get_parameter_value().bool_value
+    ros_communicator.get_logger().info(f'PyBullet GUI Parameter (gui): {use_gui}')
+    # --- 結束修改: ROS 參數處理 ---
+
     data_processor = DataProcessor(ros_communicator)
     nav2_processing = Nav2Processing(ros_communicator, data_processor)
     ik_solver = PybulletRobotController(end_eff_index=5)
     car_controller = CarController(ros_communicator, nav2_processing)
     arm_controller = ArmController(
-        ros_communicator, data_processor, ik_solver, num_joints=5
+        ros_communicator, data_processor, ik_solver, num_joints=5, use_gui=use_gui
     )
     crane_controller = CraneController(
         ros_communicator, data_processor, ik_solver, num_joints=7


### PR DESCRIPTION
在 Docker 環境中執行時，`p.connect(p.GUI)` 會因無法連接到 X Server 而失敗 (錯誤訊息: "cannot connect to X server")。 此修改將 GUI 模式下的連線方式改為 `p.connect(p.DIRECT)`，以確保可以正常啟動和運行。

完整errors:
```
 ⚡ root@6380aa841108  ~  ros2 run pros_car_py robot_control
pybullet build time: Aug  9 2024 12:32:26
startThreads creating 1 threads.
starting thread 0
started thread 0
argc=2
argv[0] = --unused
argv[1] = --start_demo_name=Physics Server
ExampleBrowserThreadFunc started
X11 functions dynamically loaded using dlopen/dlsym OK!
    cannot connect to X server
[ros2run]: Process exited with failure 1
 ✘⚡ root@6380aa841108  ~ 
```

附註：此問題在「特定用戶」 MacOS 環境(M Series)下，但不確定是否為所有 MacOS 環境的普遍問題。Docker 環境下的 X Server 連接失敗是明確的觸發原因。